### PR TITLE
Data Category Tweaks

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -29,6 +29,27 @@ goog.require('Blockly.constants');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
 
 
+Blockly.Blocks['data_variablemenu'] = {
+  /**
+   * Block of Variables
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "%1",
+      "lastDummyAlign0": "CENTRE",
+      "args0": [
+        {
+          "type": "field_variable",
+          "name": "VARIABLE"
+        }
+      ],
+      "category": Blockly.Categories.data,
+      "extensions": ["colours_data", "output_string"]
+    });
+  }
+};
+
 Blockly.Blocks['data_variable'] = {
   /**
    * Block of Variables

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -67,9 +67,11 @@ Blockly.Blocks['data_variable'] = {
           "variableType": ""
         }
       ],
+      "output": null,
       "category": Blockly.Categories.data,
       "checkboxInFlyout": true,
-      "extensions": ["contextMenu_getVariableBlock", "colours_data", "output_string"]
+      "extensions": ["contextMenu_getVariableBlock", "colours_data"],
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
   }
 };
@@ -182,9 +184,11 @@ Blockly.Blocks['data_listcontents'] = {
           "variableType": Blockly.LIST_VARIABLE_TYPE
         }
       ],
+      "output": null,
       "category": Blockly.Categories.dataLists,
-      "extensions": ["contextMenu_getListBlock", "colours_data_lists", "output_string"],
-      "checkboxInFlyout": true
+      "checkboxInFlyout": true,
+      "extensions": ["contextMenu_getListBlock", "colours_data_lists"],
+      "outputShape": Blockly.OUTPUT_SHAPE_ROUND
     });
   }
 };

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -233,13 +233,13 @@ Blockly.DataCategory.addDeleteOfList = function(xmlList, variable) {
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
 
-  //Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
-    // <block type="data_deletealloflist">
-    //   <field name="LIST" variabletype="list" id="">variablename</field>
-    // </block>
-    //Blockly.DataCategory.addBlock(xmlList, variable, 'data_deletealloflist',
-      //  'LIST');
-  //};
+//Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
+//  // <block type="data_deletealloflist">
+//  //   <field name="LIST" variabletype="list" id="">variablename</field>
+//  // </block>
+//  Blockly.DataCategory.addBlock(xmlList, variable, 'data_deletealloflist',
+//      'LIST');
+//};
 
 /**
  * Construct and add a data_insertatlist block to xmlList.

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -223,21 +223,23 @@ Blockly.DataCategory.addDeleteOfList = function(xmlList, variable) {
   //   </value>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_deleteoflist', 'LIST',
-      ['INDEX', 'math_integer', 1]);
+      ['INDEX', 'data_listindexall', 1]);
 };
 
 /**
  * Construct and add a data_deleteoflist block to xmlList.
+ * Deprecated in Unsandboxed.
  * @param {!Array.<!Element>} xmlList Array of XML block elements.
  * @param {?Blockly.VariableModel} variable Variable to select in the field.
  */
-Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
-  // <block type="data_deletealloflist">
-  //   <field name="LIST" variabletype="list" id="">variablename</field>
-  // </block>
-  Blockly.DataCategory.addBlock(xmlList, variable, 'data_deletealloflist',
-      'LIST');
-};
+
+  //Blockly.DataCategory.addDeleteAllOfList = function(xmlList, variable) {
+    // <block type="data_deletealloflist">
+    //   <field name="LIST" variabletype="list" id="">variablename</field>
+    // </block>
+    //Blockly.DataCategory.addBlock(xmlList, variable, 'data_deletealloflist',
+      //  'LIST');
+  //};
 
 /**
  * Construct and add a data_insertatlist block to xmlList.
@@ -259,7 +261,7 @@ Blockly.DataCategory.addInsertAtList = function(xmlList, variable) {
   //   </value>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_insertatlist', 'LIST',
-      ['INDEX', 'math_integer', 1], ['ITEM', 'text', Blockly.Msg.DEFAULT_LIST_ITEM]);
+      ['INDEX', 'data_listindexrandom', 1], ['ITEM', 'text', Blockly.Msg.DEFAULT_LIST_ITEM]);
 };
 
 /**
@@ -282,7 +284,7 @@ Blockly.DataCategory.addReplaceItemOfList = function(xmlList, variable) {
   //   </value>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_replaceitemoflist',
-      'LIST', ['INDEX', 'math_integer', 1], ['ITEM', 'text', Blockly.Msg.DEFAULT_LIST_ITEM]);
+      'LIST', ['INDEX', 'data_listindexrandom', 1], ['ITEM', 'text', Blockly.Msg.DEFAULT_LIST_ITEM]);
 };
 
 /**
@@ -300,7 +302,7 @@ Blockly.DataCategory.addItemOfList = function(xmlList, variable) {
   //   </value>
   // </block>
   Blockly.DataCategory.addBlock(xmlList, variable, 'data_itemoflist', 'LIST',
-      ['INDEX', 'math_integer', 1]);
+      ['INDEX', 'data_listindexrandom', 1]);
 };
 
 /** Construct and add a data_itemnumoflist block to xmlList.


### PR DESCRIPTION
- Use number dropdowns for list indexes (like Scratch 2)
- Add "data_variablemenu" for future use
- Allow "data_variable" and "data_listcontents" to be dropped anywhere
- Hide "data_deletealloflist" (to be replaced by the Scratch 2 version).