### PR TITLE
JSON: New list reporters (SB)

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -193,6 +193,31 @@ Blockly.Blocks['data_listcontents'] = {
   }
 };
 
+Blockly.Blocks['data_listarraycontents'] = {
+  /**
+   * List reporter.
+   * @this Blockly.Block
+   */
+  init: function() {
+    this.jsonInit({
+      "message0": "%1",
+      "args0": [
+        {
+          "type": "field_variable_getter",
+          "text": "",
+          "name": "LIST",
+          "variableType": Blockly.LIST_VARIABLE_TYPE
+        }
+      ],
+      "output": null,
+      "category": Blockly.Categories.dataLists,
+      "checkboxInFlyout": true,
+      "extensions": ["contextMenu_getListBlock", "colours_data_lists"],
+      "outputShape": Blockly.OUTPUT_SHAPE_SQUARE
+    });
+  }
+};
+
 Blockly.Blocks['data_listindexall'] = {
   /**
    * List index menu, with all option.

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -148,6 +148,7 @@ Blockly.Blocks['data_showvariable'] = {
 
 Blockly.Blocks['data_hidevariable'] = {
   /**
+   * @deprecated
    * Block to hide a variable
    * @this Blockly.Block
    */
@@ -170,7 +171,7 @@ Blockly.Blocks['data_hidevariable'] = {
 
 Blockly.Blocks['data_listcontents'] = {
   /**
-   * List reporter.
+   * List reporter that outputs a raw array.
    * @this Blockly.Block
    */
   init: function() {

--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -148,7 +148,6 @@ Blockly.Blocks['data_showvariable'] = {
 
 Blockly.Blocks['data_hidevariable'] = {
   /**
-   * @deprecated
    * Block to hide a variable
    * @this Blockly.Block
    */
@@ -171,7 +170,7 @@ Blockly.Blocks['data_hidevariable'] = {
 
 Blockly.Blocks['data_listcontents'] = {
   /**
-   * List reporter that outputs a raw array.
+   * List reporter.
    * @this Blockly.Block
    */
   init: function() {
@@ -196,7 +195,7 @@ Blockly.Blocks['data_listcontents'] = {
 
 Blockly.Blocks['data_listarraycontents'] = {
   /**
-   * List reporter.
+   * List reporter that outputs a raw array.
    * @this Blockly.Block
    */
   init: function() {

--- a/core/data_category.js
+++ b/core/data_category.js
@@ -205,7 +205,10 @@ Blockly.DataCategory.addDataList = function(xmlList, variable) {
   // <block id="variableId" type="data_listcontents">
   //    <field name="LIST">variablename</field>
   // </block>
-  Blockly.DataCategory.addBlock(xmlList, variable, 'data_listcontents', 'LIST');
+
+  // USB: We use a new block called "data_listarraycontents".
+  // "data_listcontents" is deprecated.
+  Blockly.DataCategory.addBlock(xmlList, variable, 'data_listarraycontents', 'LIST');
   // In the flyout, this ID must match variable ID for monitor syncing reasons
   xmlList[xmlList.length - 1].setAttribute('id', variable.getId());
 };


### PR DESCRIPTION
Add a new list reporter block that outputs to an array as opposed to an arbitrary list.

No plans are currently in place to display the old ones in the palette, but they will still exist for compatibility.